### PR TITLE
Gitpod integration

### DIFF
--- a/.gitpod-init.sh
+++ b/.gitpod-init.sh
@@ -8,7 +8,15 @@ sed -i "s|APP_URL=http://localhost|APP_URL=${GITPOD_WORKSPACE_URL}|g" .env
 sed -i "s|APP_URL=https://|APP_URL=https://80-|g" .env
 sed -i "s|DB_HOST=127.0.0.1|DB_HOST=mysql|g" .env
 sed -i "s|REDIS_HOST=127.0.0.1|REDIS_HOST=redis|g" .env
+sed -i "s|'host' => env('DB_HOST', '127.0.0.1')|'host' => env('DB_HOST', 'mysql')|g" config/database.php
+sed -i "s|'database' => env('DB_DATABASE', 'forge')|'database' => env('DB_DATABASE', 'laravel')|g" config/database.php
+sed -i "s|'username' => env('DB_USERNAME', 'forge')|'username' => env('DB_USERNAME', 'root')|g" config/database.php
+sed -i "s|'host' => env('REDIS_HOST', '127.0.0.1')|'host' => env('REDIS_HOST', 'redis')|g" config/database.php
+./vendor/bin/sail artisan cache:clear
+./vendor/bin/sail artisan route:clear
 ./vendor/bin/sail artisan config:clear
+./vendor/bin/sail artisan view:clear
 echo 'SEEDING DATABASE'
 ./vendor/bin/sail artisan key:generate
-# manually run this command -> ./vendor/bin/sail artisan migrate:fresh --seed
+./vendor/bin/sail artisan migrate:fresh --seed
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,5 +5,5 @@
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
 tasks:
-  - init: bash .gitpod-init.sh && ./vendor/bin/sail artisan migrate:fresh --seed
+  - init: bash .gitpod-init.sh
     command: npm run dev


### PR DESCRIPTION
Added gitpod.yml and gitpod-init commands. 

Manual running of these command are needed:
./vendor/bin/sail artisan migrate:fresh --seed
npm run dev 

Accessing database through gitpod-init commands causes this error:
```
   Illuminate\Database\QueryException 

  SQLSTATE[HY000] [2002] Connection refused (Connection: mysql, SQL: SHOW FULL TABLES WHERE table_type = 'BASE TABLE')

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:793
    789▕         // If an exception occurs when attempting to run a query, we'll format the error
    790▕         // message to include the bindings with SQL, which will make this exception a
    791▕         // lot more helpful to the developer instead of just the database's errors.
    792▕         catch (Exception $e) {
  ➜ 793▕             throw new QueryException(
    794▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    795▕             );
    796▕         }
    797▕     }
```
But when running migrate manually, there isn't a problem (weirdly)